### PR TITLE
feat: [#104] Скрыть номер телефона под маской

### DIFF
--- a/app_server/routes/tasks.py
+++ b/app_server/routes/tasks.py
@@ -35,7 +35,7 @@ async def get_task_info(request: Request, task_guid: str):
     task: planfix_reponses.TaskResponse = await get_task(task_guid=task_guid)
     return responses.SubscriptionTaskResponse(
         subscription_add_url=task.subscription_add_url.value if task.subscription_add_url else "",
-        client_phone=task.client_phone,
+        client_phone=task.client_phone_masked,
     )
 
 

--- a/services/planfix/api/rest/responses.py
+++ b/services/planfix/api/rest/responses.py
@@ -187,6 +187,17 @@ class TaskResponse(BaseModel):
             return ""
         return phone.strip()
 
+    @computed_field
+    @cached_property
+    def client_phone_masked(self) -> str:
+        phone = self.client_phone
+        if not phone:
+            return ""
+        digits = "".join(c for c in phone if c.isdigit())
+        if len(digits) < 8:
+            return ""
+        return f"{digits[:4]}***{digits[-4:]}"
+
 
 class TaskFilterResponse(BaseModel):
     result: str


### PR DESCRIPTION
В `TaskResponse` реализовано маскирование номера телефона клиента для повышения уровня конфиденциальности.