### PR TITLE
[#120] Оптимизация работы контейнеров

### DIFF
--- a/app_bot/bot.py
+++ b/app_bot/bot.py
@@ -18,6 +18,7 @@ from app_bot.handlers.messages import (
     user_message_with_attachment_handler,
 )
 from app_bot.utils.callback_registry import registry
+from services.http_service import BaseHTTPService
 
 logger = logging.getLogger("bot")
 
@@ -29,6 +30,10 @@ async def add_commands(app: Application):
     await app.bot.set_my_commands(commands)
 
 
+async def on_shutdown(_app: Application) -> None:
+    await BaseHTTPService.close_all()
+
+
 def build_app(token: str):
     return (
         ApplicationBuilder()
@@ -37,6 +42,7 @@ def build_app(token: str):
         .read_timeout(30)
         .write_timeout(30)
         .get_updates_read_timeout(42)
+        .post_shutdown(on_shutdown)
         .build()
     )
 
@@ -58,4 +64,10 @@ async def run_bot(token: str):
 
     await add_commands(app)
 
-    app.run_polling()
+    try:
+        app.run_polling()
+    except Exception:
+        logger.exception("Bot polling failed")
+        raise
+    finally:
+        await BaseHTTPService.close_all()

--- a/app_bot/handlers/messages.py
+++ b/app_bot/handlers/messages.py
@@ -7,6 +7,7 @@ from telegram.ext import ContextTypes
 from app_bot.s3 import s3_client
 from app_bot.utils.dialogs import clear_username
 from root.utils.others import download_file
+from root.utils.requests import get_client_timeout
 from services import planfix_webchat
 
 
@@ -30,7 +31,7 @@ async def user_message_with_attachment_handler(update: Update, context: ContextT
         f = await file.get_file()
         if not s3_client.is_configured:
             return f.file_path
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(timeout=get_client_timeout()) as session:
             file_content = await download_file(session, f.file_path)
         if not file_content:
             return ""

--- a/app_bot/utils/dialogs.py
+++ b/app_bot/utils/dialogs.py
@@ -21,6 +21,7 @@ from app_bot.const import NO_USERNAME
 from app_bot.dtos import CustomMessageRequest, MessageAttachment, NewMessageRequest
 from app_bot.exceptions import ChatNotFoundError
 from root.utils.others import download_file
+from root.utils.requests import get_client_timeout
 from services.planfix.api.rest.responses import TaskResponse
 
 
@@ -58,7 +59,7 @@ def media_to_input_file(file: bytes) -> AttachmentFile:
 
 
 async def prepare_media(attachments: list[MessageAttachment]) -> list[AttachmentFile]:
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(timeout=get_client_timeout()) as session:
         coroutines = []
         for attachment in attachments:
             coroutines.append(download_file(session, attachment.url))

--- a/app_server/app.py
+++ b/app_server/app.py
@@ -1,4 +1,5 @@
 import importlib
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
@@ -13,6 +14,7 @@ from app_server.error_handlers import app_error_handler, payment_error_handler, 
 from app_server.exceptions import PaymentError
 from root.config import settings
 from root.exceptions import AppError
+from services.http_service import BaseHTTPService
 
 limiter = Limiter(key_func=get_remote_address, default_limits=[settings.DEFAULT_RATE_LIMIT])
 
@@ -37,8 +39,14 @@ def add_middlewares(app: FastAPI):
             app.add_middleware(middleware_class, **middleware_kwargs)
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    yield
+    await BaseHTTPService.close_all()
+
+
 def init_app(service_name: str, version: str, description: str) -> FastAPI:
-    app = FastAPI(title=service_name, version=version, description=description)
+    app = FastAPI(title=service_name, version=version, description=description, lifespan=lifespan)
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,13 @@ services:
       context: .
       dockerfile: Dockerfile
     restart: always
+    mem_limit: 512m
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/health/')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     volumes:
       - ./logs:/app/logs
       - ./media:/app/media
@@ -32,6 +39,7 @@ services:
       context: .
       dockerfile: Dockerfile
     restart: always
+    mem_limit: 512m
     command: python -m bot run
 
   assets:

--- a/root/middleware/requests.py
+++ b/root/middleware/requests.py
@@ -1,6 +1,6 @@
 import logging
 
-from root.utils.requests import response_to_str
+from starlette.responses import FileResponse, StreamingResponse
 
 logger = logging.getLogger("middleware.requests")
 
@@ -9,10 +9,17 @@ async def request(request, call_next):
     """
     Middleware for request logging
     """
-    logger.info(f"Request: {request.method} {request.url}")
-    body = await request.body()
-    logger.debug(f"Request: {request.method} {request.url}. Body: {body.decode()}")
+    logger.info("Request: %s %s", request.method, request.url)
+    if logger.isEnabledFor(logging.DEBUG):
+        body = await request.body()
+        logger.debug("Request body: %s", body.decode(errors="replace"))
     response = await call_next(request)
-    data = await response_to_str(response)
-    logger.info(f"Response: {response.status_code}. Body: {data}")
+    logger.info("Response: %s", response.status_code)
+    if (
+        logger.isEnabledFor(logging.DEBUG)
+        and not isinstance(response, StreamingResponse | FileResponse)
+        and hasattr(response, "body")
+        and response.body is not None
+    ):
+        logger.debug("Response body: %s", response.body.decode(errors="replace"))
     return response

--- a/root/utils/requests.py
+++ b/root/utils/requests.py
@@ -6,7 +6,16 @@ import aiohttp
 from aiohttp import hdrs
 from starlette.responses import JSONResponse
 
+from root.config import settings
+
 logger = logging.getLogger("HTTPClient")
+
+
+def get_client_timeout() -> aiohttp.ClientTimeout:
+    return aiohttp.ClientTimeout(
+        total=settings.HTTP_CLIENT_TIMEOUT_TOTAL,
+        connect=settings.HTTP_CLIENT_TIMEOUT_CONNECT,
+    )
 
 
 async def response_to_str(response) -> str | None:

--- a/services/http_service.py
+++ b/services/http_service.py
@@ -1,8 +1,10 @@
 from copy import copy
 
+import aiohttp
 from aiohttp import ClientResponse
 from aiohttp.typedefs import Query
 
+from root.config import settings
 from root.utils.requests import LoggingClientSession
 
 
@@ -13,10 +15,12 @@ class BaseHTTPService:
         "Content-type": "application/json",
     }
     API_HOST = ""
+    _instances: list["BaseHTTPService"] = []
 
     def __init__(self, **kwargs):
         self._api_host = None
         self._session = None
+        BaseHTTPService._instances.append(self)
 
     @property
     def api_host(self):
@@ -31,7 +35,28 @@ class BaseHTTPService:
         return self._session
 
     def get_session_kwargs(self) -> dict:
-        return {"base_url": self.api_host}
+        return {
+            "base_url": self.api_host,
+            "timeout": aiohttp.ClientTimeout(
+                total=settings.HTTP_CLIENT_TIMEOUT_TOTAL,
+                connect=settings.HTTP_CLIENT_TIMEOUT_CONNECT,
+            ),
+            "connector": aiohttp.TCPConnector(
+                limit=settings.HTTP_CLIENT_CONNECTOR_LIMIT,
+                ttl_dns_cache=settings.HTTP_CLIENT_DNS_CACHE_TTL,
+                enable_cleanup_closed=True,
+            ),
+        }
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+    @classmethod
+    async def close_all(cls) -> None:
+        for instance in cls._instances:
+            await instance.close()
 
     def get_headers(self, url_name: str, method: str) -> dict:
         return copy(self.DEFAULT_HEADERS)

--- a/settings/base.py
+++ b/settings/base.py
@@ -29,6 +29,12 @@ SERVER_DESCRIPTION = env.get("SERVER_DESCRIPTION")
 REQUEST_TOKEN = env.get("REQUEST_TOKEN", default="")
 DEFAULT_RATE_LIMIT = env.get("DEFAULT_RATE_LIMIT", default="50/minute")
 
+# Таймауты и лимиты исходящих HTTP-запросов (aiohttp)
+HTTP_CLIENT_TIMEOUT_TOTAL = env.as_int("HTTP_CLIENT_TIMEOUT_TOTAL", default=30)
+HTTP_CLIENT_TIMEOUT_CONNECT = env.as_int("HTTP_CLIENT_TIMEOUT_CONNECT", default=10)
+HTTP_CLIENT_CONNECTOR_LIMIT = env.as_int("HTTP_CLIENT_CONNECTOR_LIMIT", default=50)
+HTTP_CLIENT_DNS_CACHE_TTL = env.as_int("HTTP_CLIENT_DNS_CACHE_TTL", default=300)
+
 DEFAULT_PAYMENT_AGENT = env.get("DEFAULT_PAYMENT_AGENT", "yookassa")
 # Настройки Т-кассы
 TBANK_REST_API_URL = env.get("TBANK_REST_API_URL", default="https://securepay.tinkoff.ru/v2")


### PR DESCRIPTION
### Backend
- ⚡️ Добавлены таймауты и ограничение пула соединений для исходящих HTTP-запросов (PlanFix, Т-Банк, Wata и др.)
- ⚡️ Добавлено корректное закрытие aiohttp-сессий при остановке API-сервера и Telegram-бота
- 🐛 Упрощено middleware логирования: на INFO — только метод, URL и код ответа; тело запроса/ответа — только на DEBUG
- 🐛 Исключено чтение тела streaming- и file-ответов в middleware
- 🐛 Добавлены таймауты для HTTP-сессий при загрузке файлов в боте
- 🐛 Добавлена обработка сбоев polling в боте с завершением процесса для автоперезапуска контейнера
- 🏗️ Добавлен healthcheck API-сервера через `/api/health/`
- 🏗️ Установлен лимит памяти 512m для контейнеров `server` и `bot`
- ⚙️ `HTTP_CLIENT_TIMEOUT_TOTAL = 30` — общий таймаут исходящих HTTP-запросов (сек.)
- ⚙️ `HTTP_CLIENT_TIMEOUT_CONNECT = 10` — таймаут установки соединения (сек.)
- ⚙️ `HTTP_CLIENT_CONNECTOR_LIMIT = 50` — лимит одновременных соединений в пуле
- ⚙️ `HTTP_CLIENT_DNS_CACHE_TTL = 300` — время жизни DNS-кэша (сек.)