### PR TITLE
feat: add site config preset switcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,4 +181,8 @@ logs/
 /media
 
 # Индивидуальные настройки сайта: app_server/assets/site-config.json (копировать из site-config.json.example)
-site-config.json
+site-config.json/app_server/assets/site-config.classic.json
+/app_server/assets/site-config.babochki.json
+/app_server/assets/site-config.last.json
+/app_server/assets/site-config.json
+/app_server/assets/site-config.classic.json

--- a/README.md
+++ b/README.md
@@ -375,3 +375,24 @@ docker logs outline-api-server --tail 100
 docker logs outline-api-server --tail 100 --follow
 ```
 Остановка отслеживания: `Ctrl+C`.
+
+### Локальные пресеты конфигурации
+
+Локальные файлы конфигурации:
+
+- `app_server/assets/site-config.classic.json`
+- `app_server/assets/site-config.babochki.json`
+
+Переключение на классическую тему:
+
+`./scripts/switch-site-config.sh classic`
+
+Переключение на тему «Бабочки»:
+
+`./scripts/switch-site-config.sh babochki`
+
+После переключения необходимо выполнить:
+
+`docker compose up assets`
+
+Файлы пресетов содержат локальные настройки сайта и не должны попадать в Git.

--- a/scripts/switch-site-config.sh
+++ b/scripts/switch-site-config.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MODE="${1:-}"
+
+case "$MODE" in
+  classic|babochki)
+    ;;
+  *)
+    echo "Использование:"
+    echo "  $0 classic"
+    echo "  $0 babochki"
+    exit 2
+    ;;
+esac
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ASSETS="$ROOT/app_server/assets"
+
+SOURCE="$ASSETS/site-config.$MODE.json"
+TARGET="$ASSETS/site-config.json"
+BACKUP="$ASSETS/site-config.last.json"
+
+if [[ ! -f "$SOURCE" ]]; then
+  echo "ОШИБКА: не найден файл:"
+  echo "$SOURCE"
+  exit 1
+fi
+
+python3 - "$SOURCE" "$MODE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+expected_theme = sys.argv[2]
+
+config = json.loads(path.read_text(encoding="utf-8"))
+actual_theme = config.get("site", {}).get("theme")
+
+if actual_theme != expected_theme:
+    raise SystemExit(
+        f"ОШИБКА: в {path.name} указана тема {actual_theme!r}, "
+        f"ожидалась {expected_theme!r}"
+    )
+
+print("JSON корректный.")
+print("Название:", config.get("site", {}).get("name"))
+print("Тема:", actual_theme)
+PY
+
+if [[ -f "$TARGET" ]]; then
+  cp -a "$TARGET" "$BACKUP"
+fi
+
+TEMP="$(mktemp "$ASSETS/.site-config.json.XXXXXX")"
+cp "$SOURCE" "$TEMP"
+mv "$TEMP" "$TARGET"
+
+echo
+echo "Активирован конфиг: $MODE"
+echo "Резервная копия: $BACKUP"
+echo
+echo "Для применения выполните:"
+echo "  cd $ROOT"
+echo "  docker compose up assets"


### PR DESCRIPTION
## Что сделано

- Добавлен скрипт переключения локальных конфигураций сайта:
  - `classic`
  - `babochki`
- Перед заменой активного конфига создаётся резервная копия.
- Проверяется корректность JSON и соответствие выбранной темы.
- Локальные конфиги исключены из Git.
- Добавлена инструкция в README.

## Использование

```bash
./scripts/switch-site-config.sh classic
docker compose up assets